### PR TITLE
YOV5-3 Add inference requirements

### DIFF
--- a/reqs-inference.txt
+++ b/reqs-inference.txt
@@ -8,3 +8,4 @@ PyYAML>=5.3
 torchvision
 scipy
 tqdm
+

--- a/reqs-inference.txt
+++ b/reqs-inference.txt
@@ -1,0 +1,10 @@
+numpy==1.17
+opencv-python
+torch>=1.4
+matplotlib
+pillow
+tensorboard
+PyYAML>=5.3
+torchvision
+scipy
+tqdm

--- a/reqs-inference.txt
+++ b/reqs-inference.txt
@@ -1,4 +1,4 @@
-numpy==1.17
+numpy==1.17.3
 opencv-python
 torch>=1.4
 matplotlib


### PR DESCRIPTION
## Description

Create a minimal requirements file for inference (cpu only).

* Closes #3 

## Testing

Create a python virtualenv. Example:

```commandline
$ python3 -m virtualenv venv
```

And activate with `source venv/bin/activate`

Now install requirements:

```commandline
$ pip install -r reqs-inference.txt
```
